### PR TITLE
Fixed "ImportError: cannot import name Raw" when using scapy >=2.40

### DIFF
--- a/sap_ms_betrusted.py
+++ b/sap_ms_betrusted.py
@@ -30,7 +30,11 @@ from scapy.supersocket import StreamSocket
 from scapy.sendrecv import sniff
 from scapy.utils import hexdump,inet_ntoa,inet_aton
 from scapy.packet import bind_layers
-from scapy.layers.inet import TCP,Raw
+from scapy.layers.inet import TCP
+try:
+    from scapy.layers.inet import Raw
+except ImportError:
+    from scapy.packet import Raw
 from scapy.config import conf
 from ansicolor import red,green,blue,yellow,cyan,magenta
 from pprint import pprint

--- a/sap_ms_dispatcher_mitm.py
+++ b/sap_ms_dispatcher_mitm.py
@@ -29,7 +29,11 @@ from scapy.supersocket import StreamSocket
 from scapy.sendrecv import sniff
 from scapy.utils import hexdump,inet_ntoa,inet_aton
 from scapy.packet import bind_layers
-from scapy.layers.inet import TCP,Raw
+from scapy.layers.inet import TCP
+try:
+    from scapy.layers.inet import Raw
+except ImportError:
+    from scapy.packet import Raw
 from scapy.config import conf
 from ansicolor import red,green,blue,yellow,cyan,magenta
 from pprint import pprint

--- a/sap_ms_monitor_storage.py
+++ b/sap_ms_monitor_storage.py
@@ -26,7 +26,11 @@ from pysap.SAPMS import ms_adm_opcode_values,ms_adm_rzl_strg_type_values
 from scapy.supersocket import StreamSocket
 from scapy.utils import hexdump,inet_ntoa,inet_aton
 from scapy.packet import bind_layers
-from scapy.layers.inet import TCP,Raw
+from scapy.layers.inet import TCP
+try:
+    from scapy.layers.inet import Raw
+except ImportError:
+    from scapy.packet import Raw
 from scapy.config import conf
 from ansicolor import red,green,blue,yellow,cyan,magenta
 from pprint import pprint


### PR DESCRIPTION
Running the sap_ms* scripts with Scapy 2.4.3 gave me the following error:

```
$ ./sap_ms_monitor_storage.py 
Traceback (most recent call last):
  File "./sap_ms_monitor_storage.py", line 29, in <module>
    from scapy.layers.inet import TCP,Raw
ImportError: cannot import name Raw
```

I can't pinpoint the change in Scapy which caused it, but guess it's the 2.4 release.
Anyway, importing Raw from the scapy.packet module seems to fix the issue and the "try" statement should ensure backward compatibility with older versions, but I did not test that.